### PR TITLE
Use settings.CONF_ROOT to look up catalog definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
+## 0.2.0 (01-01-2022)
+
+- GH-7: Use `settings.CONF_ROOT` to look up catalog entry definition.
+- Add a small script to launch a TCP development server for easier debugging.
+
 ## 0.1.1 (15-06-2021)
 
-* GH-1: Fix line number parsing for parameters, which allows Goto Definition to work for parameters
+- GH-1: Fix line number parsing for parameters, which allows Goto Definition to work for parameters
 
 ## 0.1.0 (13-06-2021)
 
-* Initial release
+- Initial release

--- a/kedro_lsp/server.py
+++ b/kedro_lsp/server.py
@@ -1,4 +1,5 @@
 """Kedro Language Server."""
+import logging
 import re
 from typing import List, Optional
 
@@ -142,6 +143,7 @@ def definition(server: KedroLanguageServer, params: TextDocumentPositionParams) 
         conf_path=server.project_metadata.project_path / server.project_settings.CONF_ROOT,
         patterns=["catalog*", "**/catalog*/**", "**/catalog*"],
     )
+    locations = []
 
     for catalog_path in catalog_paths:
         catalog_conf = yaml.load(catalog_path.read_text(), Loader=SafeLineLoader)
@@ -158,6 +160,19 @@ def definition(server: KedroLanguageServer, params: TextDocumentPositionParams) 
                     ),
                 ),
             )
-            return [location]
+            locations.append(location)
+    
+    return locations or None
 
-    return None
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", type=str, default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=2087)
+    args = parser.parse_args()
+    logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+    SERVER.start_tcp(args.host, args.port)

--- a/kedro_lsp/server.py
+++ b/kedro_lsp/server.py
@@ -142,8 +142,6 @@ def definition(server: KedroLanguageServer, params: TextDocumentPositionParams) 
         conf_path=server.project_metadata.project_path / server.project_settings.CONF_ROOT,
         patterns=["catalog*", "catalog*/**", "**/catalog*"]
     )
-    locations = []
-
     for catalog_path in catalog_paths:
         catalog_conf = yaml.load(catalog_path.read_text(), Loader=SafeLineLoader)
         if word in catalog_conf:
@@ -158,6 +156,6 @@ def definition(server: KedroLanguageServer, params: TextDocumentPositionParams) 
                     ),
                 ),
             )
-            locations.append(location)
+            return [location]
 
-    return locations if locations else None
+    return None

--- a/kedro_lsp/server.py
+++ b/kedro_lsp/server.py
@@ -140,10 +140,12 @@ def definition(server: KedroLanguageServer, params: TextDocumentPositionParams) 
 
     catalog_paths = _path_lookup(
         conf_path=server.project_metadata.project_path / server.project_settings.CONF_ROOT,
-        patterns=["catalog*", "catalog*/**", "**/catalog*"]
+        patterns=["catalog*", "**/catalog*/**", "**/catalog*"],
     )
+
     for catalog_path in catalog_paths:
         catalog_conf = yaml.load(catalog_path.read_text(), Loader=SafeLineLoader)
+
         if word in catalog_conf:
             line = catalog_conf[word]["__line__"]
             location = Location(


### PR DESCRIPTION
This implementation allows the look up of catalog files using the user-defined `CONF_ROOT` in `settings.py`, as opposed to a hard-coded version to `conf / base`.

It's a simpler implementation this feature request: https://github.com/Kedro-Zero-to-Hero/kedro-lsp/pull/6 without needing a session.